### PR TITLE
Fix minor typo in pattern example for number_to_phone [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -57,7 +57,7 @@ module ActionView
       #
       #   number_to_phone(75561234567, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true)
       #   # => "(755) 6123-4567"
-      #   number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})$/))
+      #   number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})$/)
       #   # => "133-1234-5678"
       def number_to_phone(number, options = {})
         return unless number


### PR DESCRIPTION
### Summary

There is an extra closing parenthesis on the last example for `number_to_phone` which causes it to be invalid

### Other Information

Documentation only change